### PR TITLE
Mensaje de error

### DIFF
--- a/src/Components/Utils/Message.component.tsx
+++ b/src/Components/Utils/Message.component.tsx
@@ -19,12 +19,16 @@ interface IMessagesProps {
 
 const Messages: React.FC<IMessagesProps> = (props) => {
   const classes = messageStyles()
-  const handleClose=()=>{
+  const handleClose = () => {
     props.setOpen(false)
   }
   return (
     <React.Fragment>
-      <Snackbar open={props.open}  onClose={handleClose}  anchorOrigin={{vertical: 'top', horizontal: 'center'}}>
+      <Snackbar
+        open={props.open}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      >
         <Alert
           className={classes.notification}
           action={

--- a/src/Components/Utils/Message.component.tsx
+++ b/src/Components/Utils/Message.component.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertTitle, Collapse, AlertColor, IconButton } from '@mui/material'
+import { Alert, AlertTitle, Collapse, AlertColor, IconButton, Snackbar } from '@mui/material'
 import React from 'react'
 import CloseIcon from '@mui/icons-material/Close'
 import makeStyles from '@mui/styles/makeStyles'
@@ -19,9 +19,12 @@ interface IMessagesProps {
 
 const Messages: React.FC<IMessagesProps> = (props) => {
   const classes = messageStyles()
+  const handleClose=()=>{
+    props.setOpen(false)
+  }
   return (
     <React.Fragment>
-      <Collapse in={props.open}>
+      <Snackbar open={props.open}  onClose={handleClose}  anchorOrigin={{vertical: 'top', horizontal: 'center'}}>
         <Alert
           className={classes.notification}
           action={
@@ -29,9 +32,7 @@ const Messages: React.FC<IMessagesProps> = (props) => {
               aria-label="close"
               color="inherit"
               size="small"
-              onClick={() => {
-                props.setOpen(false)
-              }}
+              onClick={handleClose}
               data-testid="button-close-message"
             >
               <CloseIcon fontSize="inherit" />
@@ -43,7 +44,7 @@ const Messages: React.FC<IMessagesProps> = (props) => {
           <AlertTitle>{props.title}</AlertTitle>
           {props.message}
         </Alert>
-      </Collapse>
+      </Snackbar>
     </React.Fragment>
   )
 }


### PR DESCRIPTION
**Problema:** El mensaje de error solo era visible si se encontraba en la parte superior de la pagina.

![image](https://user-images.githubusercontent.com/39476414/153854201-2d8360cc-7f28-41c3-813e-c05e8fe59d47.png)
![image](https://user-images.githubusercontent.com/39476414/153854280-d3ccd821-7dd7-4e48-8bad-46238ac81b28.png)


**Solución:** Se agrega el mensaje de error dentro de un componente `Snackbar` de _Material UI_ de esta forma se muestra sin importar en donde se encuentre el usuario.

![image](https://user-images.githubusercontent.com/39476414/153854357-7edcc04b-d032-42a3-bb41-249ebcbb161a.png)
